### PR TITLE
S3 resource changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -180,6 +180,15 @@ resource "aws_s3_bucket" "cces-s3-bucket" {
   tags          = var.aws_tags
 }
 
+resource "aws_s3_bucket_public_access_block" "cces-s3-bucket-public-access" {
+  bucket = aws_s3_bucket.cces-s3-bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "cces-s3-bucket-encryption" {
   bucket = var.s3_bucket_name == "" ? "${var.cluster_name}.bucket-do-not-delete" : var.s3_bucket_name
 

--- a/main.tf
+++ b/main.tf
@@ -180,20 +180,6 @@ resource "aws_s3_bucket" "cces-s3-bucket" {
   tags          = var.aws_tags
 }
 
-resource "aws_s3_bucket_public_access_block" "cces-s3-bucket-public-access" {
-  bucket = aws_s3_bucket.cces-s3-bucket.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-resource aws_s3_bucket_acl "cces-s3-bucket-acl" {
-  bucket = aws_s3_bucket.cces-s3-bucket.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_server_side_encryption_configuration" "cces-s3-bucket-encryption" {
   bucket = var.s3_bucket_name == "" ? "${var.cluster_name}.bucket-do-not-delete" : var.s3_bucket_name
 


### PR DESCRIPTION
Amazon have changed default behaviour for S3 buckets as of April 2023 as per: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html 

As the module stood it generated an error for new builds of the type:

Plan: 1 to add, 0 to change, 0 to destroy.
module.rubrik-cluster.module.rubrik_cluster.aws_s3_bucket_acl.cces-s3-bucket-acl: Creating...
╷
│ Error: error creating S3 bucket ACL for <bucket-name>: AccessControlListNotSupported: The bucket does not allow ACLs

I have removed the ACL resource as that is now disabled and even prior I believe private was the default anyway.
