### PR TITLE
feat(rubrik): add enable imdsv2 option and set root ebs vol tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The following are the variables accepted by the module.
 | ntp_server2_key                                 | Symmetric key material for NTP server #2. (Required with `ntp_server1_key_id` and `ntp_server1_key_type`)                | string |                            |    no    |
 | ntp_server2_key_type                            | Symmetric key type for NTP server #2. (Required with `ntp_server1_key` and `ntp_server1_key_id`)                         | string |                            |    no    |
 | timeout                                         | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.             |  int   |             60             |    no    |
+| node_boot_wait                                  | Number of seconds to wait for CCES nodes to boot before attempting to bootstrap them.                                    |  int   |             300            |    no    |
 
 ## Changes
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The following are the variables accepted by the module.
 | Name                                            | Description                                                                                                              |  Type  |          Default           | Required |
 | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | :----: | :------------------------: | :------: |
 | aws_region                                      | The region to deploy Rubrik Cloud Cluster nodes.                                                                         | string |                            |   yes    |
+| aws_instance_imdsv2                             | Enable support for IMDSv2 instances. Only supported with CCES v8.1.3 or CCES v9.0 and higher.                            |  bool  |           false            |    no    |
 | aws_instance_type                               | The type of instance to use as Rubrik Cloud Cluster nodes. CC-ES requires m5.4xlarge.                                    | string |         m5.4xlarge         |    no    |
 | aws_disable_api_termination                     | If true, enables EC2 Instance Termination Protection on the Rubrik Cloud Cluster nodes.                                  |  bool  |            true            |    no    |
 | aws_tags                                        | Tags to add to the resources that this Terraform script creates, including the Rubrik cluster nodes.                     |  map   |                            |    no    |
@@ -57,7 +58,6 @@ The following are the variables accepted by the module.
 | aws_ami_filter                                  | Cloud Cluster AWS AMI name pattern(s) to search for. Use [\"rubrik-mp-cc-<X>*\"]. Where <X> is the major version of CDM. |  list  |                            |   yes    |
 | aws_image_id                                    | AWS Image ID to deploy. Set to 'latest' or leave blank to deploy the latest version as determined by `aws_ami_filter`.   | string |           latest           |    no    |
 | aws_key_pair_name                               | Name for the AWS SSH Key-Pair being created or the existing AWS SSH Key-Pair being used.                                 | string |                            |    no    |
-| enable_imdsv2                                   | Enables IMDSv2 on the cluster node instances                                                                             | bool  |            false            |    no    |
 | private_key_recovery_window_in_days             | Recovery window in days to recover script generated ssh private key.                                                     | string |             30             |    no    |
 
 *Note: When using the `aws_tags` variable, the "Name" tag is automatically used by this TF for those resources that support it.*

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following are the variables accepted by the module.
 | aws_ami_filter                                  | Cloud Cluster AWS AMI name pattern(s) to search for. Use [\"rubrik-mp-cc-<X>*\"]. Where <X> is the major version of CDM. |  list  |                            |   yes    |
 | aws_image_id                                    | AWS Image ID to deploy. Set to 'latest' or leave blank to deploy the latest version as determined by `aws_ami_filter`.   | string |           latest           |    no    |
 | aws_key_pair_name                               | Name for the AWS SSH Key-Pair being created or the existing AWS SSH Key-Pair being used.                                 | string |                            |    no    |
+| enable_imdsv2                                   | Enables IMDSv2 on the cluster node instances                                                                             | bool  |            false            |    no    |
 | private_key_recovery_window_in_days             | Recovery window in days to recover script generated ssh private key.                                                     | string |             30             |    no    |
 
 *Note: When using the `aws_tags` variable, the "Name" tag is automatically used by this TF for those resources that support it.*

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -107,6 +107,7 @@ The following are the variables accepted by the module.
 | ntp_server2_key                                 | Symmetric key material for NTP server #2. (Required with `ntp_server1_key_id` and `ntp_server1_key_type`)                | string |                            |    no    |
 | ntp_server2_key_type                            | Symmetric key type for NTP server #2. (Required with `ntp_server1_key` and `ntp_server1_key_id`)                         | string |                            |    no    |
 | timeout                                         | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.             |  int   |             60             |    no    |
+| node_boot_wait                                  | Number of seconds to wait for CCES nodes to boot before attempting to bootstrap them.                                    |  int   |             300            |    no    |
 
 ## Running the Terraform Configuration
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -34,6 +34,7 @@ The following are the variables accepted by the module.
 | Name                                            | Description                                                                                                              |  Type  |          Default           | Required |
 | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | :----: | :------------------------: | :------: |
 | aws_region                                      | The region to deploy Rubrik Cloud Cluster nodes.                                                                         | string |                            |   yes    |
+| aws_instance_imdsv2                             | Enable support for IMDSv2 instances. Only supported with CCES v8.1.3 or CCES v9.0 and higher.                            |  bool  |           false            |    no    |
 | aws_instance_type                               | The type of instance to use as Rubrik Cloud Cluster nodes. CC-ES requires m5.4xlarge.                                    | string |         m5.4xlarge         |    no    |
 | aws_disable_api_termination                     | If true, enables EC2 Instance Termination Protection on the Rubrik Cloud Cluster nodes.                                  |  bool  |            true            |    no    |
 | aws_tags                                        | Tags to add to the resources that this Terraform script creates, including the Rubrik cluster nodes.                     |  map   |                            |    no    |
@@ -277,9 +278,9 @@ The Rubik product in the AWS Marketplace must be subscribed to. Otherwise an err
 If this occurs, open the specific link from the error, while logged into the AWS account where Cloud Cluster will be deployed. Follow the instructions for subscribing to the product.
 For AWS GovCloud the link points to the public marketplace. Instead of following the link, launch one instance of the major version of Rubrik from the AWS console. This will accept the terms and subscribe to the subscription. Remove the manually launched instance and then run the Terraform again.
 
-### Instance Metadata Service Version 2 (IMDSv2) not supported
+### Instance Metadata Service Version 2 (IMDSv2) not supported by CCES v8.1.2 and older
 
-The AWS Instance Metadata Service Version 2 (IMDSv2) is not supported at this time with CCES. If after deploying the CCES node, SSH fails to login or bootstrapping the node fails. When trying to ssh to the node the following error may occur:
+The AWS Instance Metadata Service Version 2 (IMDSv2) is not supported at this time with CCES v8.1.2 and older. This problem manifests itself after deploying the CCES node. SSH to the node fails to login and bootstrapping the node fails. When trying to ssh to the node the following error may occur:
 
 ```
 admin@<node_ip_address>: Permission denied (publickey).
@@ -332,4 +333,4 @@ Checking the bootstrap status using the REST API endpoint with a command such as
 }
 ```
 
-If any of these errors occur, the Instance Metadata Service Version 2 (IMDSv2) may be enabled. This can happen if the Terraform `aws_instance` module has the `metadata_options` variable `http_tokens` set to `required`. To fix this remove the `http_tokens` variable.
+If any of these errors occur, the Instance Metadata Service Version 2 (IMDSv2) may be enabled. This can happen if the option `aws_instance_imdsv2` is set to `true` in this module.  To fix this set the `aws_instance_imdsv2` variable to false or upgrade to CCES v8.1.3 and CCES v9.0 or higher.

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ locals {
     "tags"                    = var.aws_tags
     "root_volume_type"        = var.cluster_disk_type
     "root_volume_throughput"  = local.ebs_throughput
-    "http_tokens"             = var.enable_imdsv2 ? "required" : "optional"
+    "http_tokens"             = var.aws_instance_imdsv2 ? "required" : "optional"
   }
 
   cluster_node_ips = [for i in module.cluster_nodes.instances : i.private_ip]

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ locals {
     "tags"                    = var.aws_tags
     "root_volume_type"        = var.cluster_disk_type
     "root_volume_throughput"  = local.ebs_throughput
+    "http_tokens"             = var.enable_imdsv2 ? "required" : "optional"
   }
 
   cluster_node_ips = [for i in module.cluster_nodes.instances : i.private_ip]
@@ -224,7 +225,7 @@ module "cluster_nodes" {
 ###########################k###########
 
 resource "time_sleep" "wait_for_nodes_to_boot" {
-  create_duration = "300s"
+  create_duration = "${var.node_boot_wait}s"
 
   depends_on = [module.cluster_nodes]
 }

--- a/modules/rubrik_aws_instances/main.tf
+++ b/modules/rubrik_aws_instances/main.tf
@@ -5,6 +5,9 @@ resource "aws_instance" "rubrik_cluster" {
   vpc_security_group_ids = var.node_config.sg_ids
   subnet_id = var.node_config.subnet_id
   key_name  = var.node_config.key_pair_name
+  metadata_options {
+    http_tokens = var.node_config.http_tokens
+  }  
   lifecycle {
     ignore_changes = [ami]
   }
@@ -16,10 +19,13 @@ resource "aws_instance" "rubrik_cluster" {
   disable_api_termination = var.node_config.disable_api_termination
   iam_instance_profile    = var.node_config.iam_instance_profile
   root_block_device {
-    encrypted = true
+    encrypted   = true
     volume_type = var.node_config.root_volume_type
-    throughput = var.node_config.root_volume_throughput
-    tags = {Name = "${each.value}-sda"}
+    throughput  = var.node_config.root_volume_throughput
+    tags        = merge(
+                        {Name = "${each.value}-sda"},
+                        var.node_config.tags      
+    )
   }
   dynamic "ebs_block_device"{
     for_each = var.disks
@@ -27,7 +33,7 @@ resource "aws_instance" "rubrik_cluster" {
       volume_type = ebs_block_device.value.type
       volume_size = ebs_block_device.value.size
       throughput  = ebs_block_device.value.throughput
-      tags        =  merge(
+      tags        = merge(
                           {Name = "${each.key}-${element(split("/", ebs_block_device.value.device), 2)}"},
                           var.node_config.tags      
       )

--- a/modules/rubrik_aws_instances/variables.tf
+++ b/modules/rubrik_aws_instances/variables.tf
@@ -15,6 +15,7 @@ variable "node_config" {
     root_volume_type = string
     root_volume_throughput = number
     tags = map(string)
+    http_tokens = string
   })
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -180,47 +180,67 @@ variable "ntp_server1_name" {
   type        = string
   default     = "8.8.8.8"
 }
+
 variable "ntp_server1_key_id" {
   description = "The ID number of the symmetric key used with NTP server #1. (Typically this is 0)"
   type        = number
   default     = 0
 }
+
 variable "ntp_server1_key" {
   description = "Symmetric key material for NTP server #1."
   type        = string
   sensitive   = true
   default     = ""
 }
+
 variable "ntp_server1_key_type" {
   description = "Symmetric key type for NTP server #1."
   type        = string
   sensitive   = true
   default     = ""
 }
+
 variable "ntp_server2_name" {
   description = "The FQDN or IPv4 addresses of network time protocol (NTP) server #2."
   type        = string
   default     = "8.8.4.4"
 }
+
 variable "ntp_server2_key_id" {
   description = "The ID number of the symmetric key used with NTP server #2. (Typically this is 0)"
   type        = number
   default     = 0
 }
+
 variable "ntp_server2_key" {
   description = "Symmetric key material for NTP server #2."
   type        = string
   sensitive   = true
   default     = ""
 }
+
 variable "ntp_server2_key_type" {
   description = "Symmetric key type for NTP server #2."
   type        = string
   sensitive   = true
   default     = ""
 }
+
 variable "timeout" {
   description = "The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error."
   type        = number
   default     = 60
+}
+
+variable "enable_imdsv2" {
+  description = "Determines if IMDSv2 is enabled."
+  type        = bool
+  default     = false
+}
+
+variable "node_boot_wait" {
+  description = "Number of seconds to wait for nodes to boot."
+  type        = number
+  default     = 300
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "aws_region" {
   type        = string
 }
 
+variable "aws_instance_imdsv2" {
+  description = "Enable support for IMDSv2 instances. Only supported with CCES v8.1.3 or CCES v9.0 and higher."
+  type        = bool
+  default     = false
+}
+
 variable "aws_instance_type" {
   description = "The type of instance to use as Rubrik Cloud Cluster nodes. CC-ES requires m5.4xlarge."
   type        = string
@@ -233,14 +239,8 @@ variable "timeout" {
   default     = 60
 }
 
-variable "enable_imdsv2" {
-  description = "Determines if IMDSv2 is enabled."
-  type        = bool
-  default     = false
-}
-
 variable "node_boot_wait" {
-  description = "Number of seconds to wait for nodes to boot."
+  description = "Number of seconds to wait for CCES nodes to boot before attempting to bootstrap them."
   type        = number
   default     = 300
 }


### PR DESCRIPTION
# Description

Add the option of enabling IMDSv2 on the cluster EC2 instances with the default being disabled for backward compatibility.
Additionally tags are now added to the root EBS volume.

## Related Issue

[Add option to enable IMDSv2 on cluster instances #9](https://github.com/rubrikinc/terraform-aws-rubrik-cloud-cluster-elastic-storage/issues/9)

## Motivation and Context

Internal security policies can mandate that IMDSv2 is enabled. 

## How Has This Been Tested?

* Clusters created and existing clusters updated

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
