### PR TITLE
Enable immutability by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The following are the variables accepted by the module.
 | create_s3_bucket                                | If true, create am S3 bucket for Cloud Cluster ES data storage.                                                          |  bool  |           true             |    no    |
 | s3_bucket_name                                  | Name of the S3 bucket to use with Cloud Cluster ES data storage. If blank a name will be auto generated.                 | string |                            |    no    |
 | s3_bucket_force_destroy                         | Indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error.               |  bool  |           false            |    no    |
-| enable_immutability                             | Enable immutability on the S3 objects that CCES uses. Default value is false.                                            |  bool  |           false            |    no    |
+| enable_immutability                             | Enable immutability on the S3 objects that CCES uses. Default value is true.                                            |  bool  |           true            |    no    |
 | create_s3_vpc_endpoint                          | If true, create a VPC Endpoint and S3 Endpoint Service for Cloud Cluster ES.                                             |  bool  |           true             |    no    |
 
 #### Bootstrap Settings

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -85,7 +85,7 @@ The following are the variables accepted by the module.
 | create_s3_bucket                                | If true, create am S3 bucket for Cloud Cluster ES data storage.                                                          |  bool  |           true             |    no    |
 | s3_bucket_name                                  | Name of the S3 bucket to use with Cloud Cluster ES data storage. If blank a name will be auto generated.                 | string |                            |    no    |
 | s3_bucket_force_destroy                         | Indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error.               |  bool  |           false            |    no    |
-| enable_immutability                             | Enable immutability on the S3 objects that CCES uses. Default value is false.                                            |  bool  |           false            |    no    |
+| enable_immutability                             | Enable immutability on the S3 objects that CCES uses. Default value is true.                                            |  bool  |           true            |    no    |
 | create_s3_vpc_endpoint                          | If true, create a VPC Endpoint and S3 Endpoint Service for Cloud Cluster ES.                                             |  bool  |           true             |    no    |
 
 ### Bootstrap Settings


### PR DESCRIPTION
# Description

Document immutability enabled by default

## Related Issue

https://github.com/rubrikinc/terraform-aws-rubrik-cloud-cluster-elastic-storage/issues/11

## Motivation and Context

Enabled immutability is required to initiate cluster recoverability on lost or deleted cloud clusters. 
Since immutability by default [was enabled previously](https://github.com/codecudi/terraform-aws-rubrik-cloud-cluster-elastic-storage/commit/e45b6e9851400a197b92f2f852c167a20d61475b#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR129) for cloud clusters deployed through Terraform, this diff just updates the documentation to reflect that.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
