### PR TITLE
Update the module to use the RSC provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -230,23 +230,19 @@ resource "time_sleep" "wait_for_nodes_to_boot" {
   depends_on = [module.cluster_nodes]
 }
 
-resource "rubrik_bootstrap_cces_aws" "bootstrap_rubrik_cces_aws" {
-  cluster_name            = "${var.cluster_name}"
-  admin_email             = "${var.admin_email}"
-  admin_password          = "${var.admin_password}"
-  management_gateway      = "${cidrhost(data.aws_subnet.rubrik_cloud_cluster.cidr_block, 1)}"
-  management_subnet_mask  = "${cidrnetmask(data.aws_subnet.rubrik_cloud_cluster.cidr_block)}"
-  dns_search_domain       = "${var.dns_search_domain}"
-  dns_name_servers        = "${var.dns_name_servers}"
-  ntp_server1_name        = "${var.ntp_server1_name}"
-  ntp_server2_name        = "${var.ntp_server2_name}"
-
-  enable_encryption       = false
-  bucket_name             = var.s3_bucket_name == "" ? "${var.cluster_name}.bucket-do-not-delete" : var.s3_bucket_name
-  enable_immutability     = var.enableImmutability
-
-  node_config             = "${zipmap(local.cluster_node_names, local.cluster_node_ips)}"
-  timeout                 = "${var.timeout}"
-
-  depends_on              = [time_sleep.wait_for_nodes_to_boot]
+resource "polaris_cdm_bootstrap_cces_aws" "bootstrap_cces_aws" {
+  cluster_name           = var.cluster_name
+  cluster_nodes          = zipmap(local.cluster_node_names, local.cluster_node_ips)
+  admin_email            = var.admin_email
+  admin_password         = var.admin_password
+  management_gateway     = cidrhost(data.aws_subnet.rubrik_cloud_cluster.cidr_block, 1)
+  management_subnet_mask = cidrnetmask(data.aws_subnet.rubrik_cloud_cluster.cidr_block)
+  dns_search_domain      = var.dns_search_domain
+  dns_name_servers       = var.dns_name_servers
+  ntp_server1_name       = var.ntp_server1_name
+  ntp_server2_name       = var.ntp_server2_name
+  bucket_name            = var.s3_bucket_name == "" ? "${var.cluster_name}.bucket-do-not-delete" : var.s3_bucket_name
+  enable_immutability    = var.enableImmutability
+  timeout                = var.timeout
+  depends_on             = [time_sleep.wait_for_nodes_to_boot]
 }

--- a/providers.tf
+++ b/providers.tf
@@ -4,8 +4,9 @@ terraform {
     aws = {
       source = "hashicorp/aws"
     }
-    rubrik = {
-      source   = "rubrikinc/rubrik/rubrik"
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = "=0.8.0-beta.4"
     }
   }
 }
@@ -15,9 +16,4 @@ provider "aws" {
   region = var.aws_region
 }
 
-provider "rubrik" {
-#  node_ip  = "${module.cluster_nodes.instances.0.private_ip}"
-  node_ip  = local.cluster_node_ips.0
-  username = ""
-  password = ""
-}
+provider "polaris" {}

--- a/variables.tf
+++ b/variables.tf
@@ -235,8 +235,8 @@ variable "ntp_server2_key_type" {
 
 variable "timeout" {
   description = "The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error."
-  type        = number
-  default     = 60
+  type        = string
+  default     = "4m"
 }
 
 variable "node_boot_wait" {


### PR DESCRIPTION
# Description

Update the module to use the RSC Terraform provider instead of the CDM Terraform provider.

## Motivation and Context

The RSC Terraform provider is published to the Terraform Registry making it much easier to use than the CDM Terraform provider.

## How Has This Been Tested?

* Deployed an AWS CCES cluster and verified that it was up and running.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
