### PR TITLE
feat(rubrik): make s3 vpc endpoint creation optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ The following are the variables accepted by the module.
 | create_s3_bucket                                | If true, create am S3 bucket for Cloud Cluster ES data storage.                                                          |  bool  |           true             |    no    |
 | s3_bucket_name                                  | Name of the S3 bucket to use with Cloud Cluster ES data storage. If blank a name will be auto generated.                 | string |                            |    no    |
 | s3_bucket_force_destroy                         | Indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error.               |  bool  |           false            |    no    |
-| enable_immutability                             | Enable immutability on the S3 objects that CCES uses. Default value is true.                                            |  bool  |           true            |    no    |
+| enableImmutability                             | Enable immutability on the S3 objects that CCES uses. Default value is true.                                            |  bool  |           true            |    no    |
 | create_s3_vpc_endpoint                          | If true, create a VPC Endpoint and S3 Endpoint Service for Cloud Cluster ES.                                             |  bool  |           true             |    no    |
+| s3_vpc_endpoint_route_table_ids                          | Route table IDs for VPC Endpoint and S3 Endpoint Service.                                             |  list  |                       |    no    |
 
 #### Bootstrap Settings
 

--- a/main.tf
+++ b/main.tf
@@ -158,11 +158,13 @@ module "iam_role" {
 ########################################
 
 module "s3_vpc_endpoint" {
+  count  = var.create_s3_vpc_endpoint ? 1 : 0
   source = "./modules/s3_vpc_endpoint"
 
-  vpc_id = data.aws_subnet.rubrik_cloud_cluster.vpc_id
-  
-  tags =  merge(
+  vpc_id          = data.aws_subnet.rubrik_cloud_cluster.vpc_id
+  route_table_ids = var.s3_vpc_endpoint_route_table_ids
+
+  tags = merge(
     { Name = "${var.cluster_name}:ep" },
     var.aws_tags
   )

--- a/modules/s3_vpc_endpoint/main.tf
+++ b/modules/s3_vpc_endpoint/main.tf
@@ -4,6 +4,7 @@ resource "aws_vpc_endpoint" "s3_endpoint" {
   vpc_id            = var.vpc_id
   service_name      = "com.amazonaws.${data.aws_region.current.id}.s3"
   vpc_endpoint_type = "Gateway"
+  route_table_ids   = var.route_table_ids
 
   tags = var.tags
 }

--- a/modules/s3_vpc_endpoint/variables.tf
+++ b/modules/s3_vpc_endpoint/variables.tf
@@ -4,7 +4,7 @@ variable "vpc_id" {
 
 variable "route_table_ids" {
   type    = list(string)
-  default = null
+  default = []
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -151,6 +151,18 @@ variable "s3_bucket_force_destroy" {
   default     = false
 }
 
+variable "create_s3_vpc_endpoint" {
+  description = "Determines whether an S3 VPC endpoint is created."
+  type        = bool
+  default     = true
+}
+
+variable "s3_vpc_endpoint_route_table_ids" {
+  description = "Route table IDs if S3 VPC endpoint is created."
+  type        = list(string)
+  default     = []
+}
+
 # Bootstrap Settings
 variable "cluster_name" {
   description = "Unique name to assign to the Rubrik Cloud Cluster. This will also be used to populate the EC2 instance name tag. For example, rubrik-cloud-cluster-1, rubrik-cloud-cluster-2 etc."


### PR DESCRIPTION
# Description

This PR adds the code behind the variable "create_s3_vpc_endpoint" discussed in the README but not implemented.

## Related Issue

Enhancement: https://github.com/rubrikinc/terraform-aws-rubrik-cloud-cluster-elastic-storage/issues/15

## Motivation and Context

We have no requirement for the Rubrik module to create the S3 VPC endpoints.

## How Has This Been Tested?

New cluster created with and without VPC endpoint and registered in RSC

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
