### PR TITLE
Add support for CDM versions using split disks

### DIFF
--- a/modules/rubrik_aws_instances/variables.tf
+++ b/modules/rubrik_aws_instances/variables.tf
@@ -20,5 +20,10 @@ variable "node_config" {
 }
 
 variable "disks" {
-  type = map(any)
+  type = list(object({
+    device     = string
+    size       = number
+    type       = string
+    throughput = number
+  }))
 }

--- a/split_disk.tf
+++ b/split_disk.tf
@@ -1,0 +1,22 @@
+data "aws_ami" "cces_ami" {
+  filter {
+    name   = "image-id"
+    values = [local.ami_id]
+  }
+}
+
+locals {
+  # Regular expression parsing the version number from the CCES AMI name.
+  version_regex = "^rubrik-mp-cc-(\\d+)-(\\d+)-(\\d+).+$"
+
+  # Extract the major, minor and maintenance version numbers from the CCES AMI
+  # name.
+  major_minor_maint = regex(local.version_regex, data.aws_ami.cces_ami.name)
+  major_version     = parseint(local.major_minor_maint[0], 10)
+  minor_version     = parseint(local.major_minor_maint[1], 10)
+  maint_version     = parseint(local.major_minor_maint[2], 10)
+
+  # Determine if the split disk feature is enabled based on the major, minor and
+  # maintenance version numbers.
+  split_disk = local.major_version < 9 || (local.major_version == 9 && local.minor_version < 2) || (local.major_version == 9 && local.minor_version == 2 && local.maint_version < 2) ? false : true
+}


### PR DESCRIPTION
# Description

CDM version 9.2.2 and later uses a split disk (metadata and cache), update the Terraform configuration to create the additional disks when needed. There are no additional input required by the user.

## How Has This Been Tested?

Tested by deploying an older and a newer CCES cluster to AWS and verifying that the all required disks were created.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)