### PR TITLE
Reduce non-data disk throughput when using split disks to 125

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ locals {
     "availability_zone"       = data.aws_subnet.rubrik_cloud_cluster.availability_zone,
     "tags"                    = var.aws_tags
     "root_volume_type"        = var.cluster_disk_type
-    "root_volume_throughput"  = local.ebs_throughput
+    "root_volume_throughput"  = local.split_disk ? 125 : local.ebs_throughput
     "http_tokens"             = var.aws_instance_imdsv2 ? "required" : "optional"
   }
 
@@ -32,13 +32,13 @@ locals {
     device     = "/dev/sdb"
     size       = 132
     type       = "gp3"
-    throughput = 250
+    throughput = 125
   }
   cache_disk = {
     device     = "/dev/sdc"
     size       = 206
     type       = "gp3"
-    throughput = 250
+    throughput = 125
   }
   cluster_disks = concat(
     local.split_disk ? [local.metadata_disk, local.cache_disk] : [],

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -4,8 +4,6 @@ variable "aws_vpc_security_group_ids" {
   type = "list"
 }
 
-variable "aws_subnet_id" {}
-
 module "rubrik_aws_cloud_cluster_elastic_storage" {
   source = "../"
 

--- a/variables.tf
+++ b/variables.tf
@@ -98,7 +98,7 @@ variable "aws_subnet_id" {
 # Storage Settings
 
 variable "cluster_disk_type" {
-  description = "Disk type for the cache disk: gp2, gp3. Note gp3 only supported for CC-ES from Rubrik 8.1.1."
+  description = "Disk type for the data disk: gp2 or gp3. Note, gp3 is only supported from version 8.1.1 for Cloud Cluster ES."
   type        = string
   default     = "gp3"
 }


### PR DESCRIPTION
# Description

When using separate disks for metadata and cache the throughput for those disks and the root disk can be reduced to 125.

## How Has This Been Tested?

Created two CCES test clusters, one with version 9.1.X and one with 9.3.X, and verified the disk layouts and parameters. 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
