### PR TITLE
Remove redundant empty provider block

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -11,9 +11,6 @@ terraform {
   }
 }
 
-# Configure the AWS Provider
 provider "aws" {
   region = var.aws_region
 }
-
-provider "polaris" {}


### PR DESCRIPTION
# Description

Removes the redundant empty provider block from the providers.tf file. 

## Related Issue

Closes https://github.com/rubrikinc/terraform-aws-rubrik-cloud-cluster-elastic-storage/issues/22.

## How Has This Been Tested?

Tested by creating an AWS CCES cluster both with and without the change in this PR.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
