### PR TITLE
Update terraform-provider-polaris to v1.1.0-beta.4

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -6,7 +6,7 @@ terraform {
     }
     polaris = {
       source  = "rubrikinc/polaris"
-      version = "=1.1.0-beta.3"
+      version = "=1.1.0-beta.4"
     }
   }
 }


### PR DESCRIPTION
# Description

terraform-provider-polaris v1.1.0-beta.4 contains backwards compatibility fixes with terraform-provider-rubrik, making it easier to migrate the module state to versions using the new provider.

## How Has This Been Tested?

* Created a new AWS CCES cluster from scratch.
* Migrated an existing AWS CCES cluster from version 1.3.0.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
