### PR TITLE
Clarify split_disk must match original build version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.6.2
+
+- Update `split_disk` variable documentation to clarify that the value must match the CDM version the cluster was
+  originally built with, not the current version after any upgrades.
+
 ## v1.6.1
 
 - Add optional `split_disk` variable to manually override split disk auto-detection. When set, the AMI lookup used to

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ module "rubrik_aws_cloud_cluster" {
 
 ## Changelog
 
+### v1.6.2
+
+- Update `split_disk` variable documentation to clarify that the value must match the CDM version the cluster was
+  originally built with, not the current version after any upgrades.
+
 ### v1.6.1
 
 - Add optional `split_disk` variable to manually override split disk auto-detection. When set, the AMI lookup used to
@@ -206,7 +211,8 @@ AMIs, Terraform cannot look up the AMI ID automatically.
 
 **Fix:** Set the `aws_image_id` variable to the specific AMI ID of the existing cluster instances. The `split_disk`
 variable must also be set explicitly because the AMI version lookup used for auto-detection is also skipped. Set
-`split_disk` to `true` for CDM 9.2.2 and later, or `false` for earlier CDM versions.
+`split_disk` to `true` for CDM 9.2.2 and later, or `false` for earlier CDM versions. Use the CDM version the cluster
+was originally built with, not the current version after any upgrades.
 
 ### Error: Your query returned no results
 
@@ -226,7 +232,8 @@ split-disk auto-detection in `split_disk.tf` still tries to resolve the AMI meta
 CDM version. When the AMI has been deregistered, this lookup fails.
 
 **Fix:** Set the `split_disk` variable explicitly to skip the AMI metadata lookup entirely. Use `true` for CDM 9.2.2
-and later, or `false` for earlier CDM versions.
+and later, or `false` for earlier CDM versions. Use the CDM version the cluster was originally built with, not the
+current version after any upgrades.
 
 ## How You Can Help
 
@@ -300,7 +307,7 @@ welcome. Thank you in advance for all of your issues, pull requests, and comment
 | <a name="input_enable_immutability"></a> [enable\_immutability](#input\_enable\_immutability) | Enables object lock and versioning on the S3 bucket. Sets the object lock flag during bootstrap. Not supported on CDM v8.0.1 and earlier. | `bool` | `null` | no |
 | <a name="input_register_cluster_with_rsc"></a> [register\_cluster\_with\_rsc](#input\_register\_cluster\_with\_rsc) | Register the Rubrik Cloud Cluster with Rubrik Security Cloud. | `bool` | `false` | no |
 | <a name="input_s3_bucket_force_destroy"></a> [s3\_bucket\_force\_destroy](#input\_s3\_bucket\_force\_destroy) | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. | `bool` | `false` | no |
-| <a name="input_split_disk"></a> [split\_disk](#input\_split\_disk) | Manually override the split disk feature. When set, the AMI lookup used to determine the CDM version is skipped. Set to `true` for CDM >= 9.2.2, `false` for earlier versions. Leave as `null` to auto-detect from the AMI. | `bool` | `null` | no |
+| <a name="input_split_disk"></a> [split\_disk](#input\_split\_disk) | Manually override the split disk feature. When set, the AMI lookup used to determine the CDM version is skipped. Set to `true` for CDM >= 9.2.2, `false` for earlier versions. Leave as `null` to auto-detect from the AMI. Note: the value must match the CDM version the cluster was originally built with, not the current version after any upgrades. Changing this value on an existing cluster will cause the cluster nodes to be rebuilt. | `bool` | `null` | no |
 | <a name="input_dns_name_servers"></a> [dns\_name\_servers](#input\_dns\_name\_servers) | List of the IPv4 addresses of the DNS servers. | `list(any)` | <pre>[<br/>  "169.254.169.253"<br/>]</pre> | no |
 | <a name="input_dns_search_domain"></a> [dns\_search\_domain](#input\_dns\_search\_domain) | List of search domains that the DNS Service will use to resolve hostnames that are not fully qualified. | `list(any)` | `[]` | no |
 | <a name="input_aws_cloud_cluster_nodes_sg_ids"></a> [aws\_cloud\_cluster\_nodes\_sg\_ids](#input\_aws\_cloud\_cluster\_nodes\_sg\_ids) | Additional security groups to add to Rubrik cluster nodes. | `list(string)` | `[]` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -99,7 +99,7 @@ variable "aws_subnet_id" {
 # Storage settings.
 
 variable "split_disk" {
-  description = "Manually override the split disk feature. When set, the AMI lookup used to determine the CDM version is skipped. Set to `true` for CDM >= 9.2.2, `false` for earlier versions. Leave as `null` to auto-detect from the AMI."
+  description = "Manually override the split disk feature. When set, the AMI lookup used to determine the CDM version is skipped. Set to `true` for CDM >= 9.2.2, `false` for earlier versions. Leave as `null` to auto-detect from the AMI. Note: the value must match the CDM version the cluster was originally built with, not the current version after any upgrades. Changing this value on an existing cluster will cause the cluster nodes to be rebuilt."
   type        = bool
   default     = null
 }


### PR DESCRIPTION
# Description

Update the split_disk variable description and troubleshooting sections to clarify that the value must match the CDM version the cluster was originally built with, not the current version after any upgrades. Changing the value on an existing cluster will cause the cluster nodes to be rebuilt.

## How Has This Been Tested?

Purely a documentation change.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](CONTRIBUTING.md)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
