### PR TITLE
Pin security-group module to 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.6.3
+
+- Pin the `terraform-aws-modules/security-group/aws` module to `~> 5.0`. Version 6.0.0 of that module is a rewrite that
+  removed the `ingress_with_self`, `ingress_with_source_security_group_id`, and `ingress_with_cidr_blocks` inputs (and
+  requires AWS provider 6.x), which broke this module since no version constraint was previously set.
+
 ## v1.6.2
 
 - Update `split_disk` variable documentation to clarify that the value must match the CDM version the cluster was

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,8 @@ module "aws_key_pair" {
 # Create, then configure, the Security Groups for the Rubrik Cluster #
 ######################################################################
 module "rubrik_nodes_sg" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
 
   use_name_prefix = true
   name            = var.aws_vpc_cloud_cluster_nodes_sg_name == "" ? "${var.cluster_name}.sg" : var.aws_vpc_cloud_cluster_nodes_sg_name
@@ -135,7 +136,8 @@ module "rubrik_nodes_sg_rules" {
 }
 
 module "rubrik_hosts_sg" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
 
   use_name_prefix = true
   name            = var.aws_vpc_cloud_cluster_hosts_sg_name == "" ? "${var.cluster_name}.sg" : var.aws_vpc_cloud_cluster_hosts_sg_name

--- a/modules/rubrik_hosts_sg/main.tf
+++ b/modules/rubrik_hosts_sg/main.tf
@@ -1,5 +1,6 @@
 module "this" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
 
   create_sg         = false
   security_group_id = var.sg_id

--- a/modules/rubrik_nodes_sg/main.tf
+++ b/modules/rubrik_nodes_sg/main.tf
@@ -1,5 +1,6 @@
 module "this" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
 
   create_sg         = false
   security_group_id = var.sg_id


### PR DESCRIPTION
## Summary
- `terraform-aws-modules/security-group/aws` v6.0.0 (a rewrite that removed the `ingress_with_*` inputs this module relies on) was being pulled because no version was pinned, breaking the module.
- Pin all four call sites to `~> 5.0` (resolves to 5.3.1).
- Add CHANGELOG entry for v1.6.3.

## Validation
- `terraform init` resolves the security-group module to 5.3.1; v6.0.0 excluded.
- `terraform validate` passes.